### PR TITLE
Standardize code replacement strings - UWP quickstart

### DIFF
--- a/active-directory-dotnet-native-uwp-v2/MainPage.xaml.cs
+++ b/active-directory-dotnet-native-uwp-v2/MainPage.xaml.cs
@@ -31,7 +31,7 @@ namespace active_directory_dotnet_native_uwp_v2
         //   - for any Work or School accounts, use organizations
         //   - for any Work or School accounts, or Microsoft personal account, use common
         //   - for Microsoft Personal account, use consumers
-        private const string ClientId = "0b8b0665-bc13-4fdc-bd72-e0227b9fc011";        
+        private const string ClientId =  "Enter_the_Application_Id_here" 
 
         public IPublicClientApplication PublicClientApp { get; } 
 


### PR DESCRIPTION
We have a working prototype to improve developer experience in quickstarts so that the downloaded code sample is ready-to-run and no longer needs manual step of copy-pasting the code blob with clientId/password/etc info. For that, we're standardizing code replacement strings as follows:
ClientIdStringToReplace : "Enter_the_Application_Id_here"