### PR TITLE
Update redirect URI?

### DIFF
--- a/AppCreationScripts/apps.json
+++ b/AppCreationScripts/apps.json
@@ -15,7 +15,7 @@
       "x-ms-version": "2.0",
       "replyUrlsWithType": [
         {
-          "url": "urn:ietf:wg:oauth:2.0:oob",
+          "url": "https://login.microsoftonline.com/common/oauth2/nativeclient",
           "type": "InstalledClient"
         }
       ],


### PR DESCRIPTION
Currently pointing to "urn:ietf..". Should it be "https://login.microsoftonline.com/common/oauth2/nativeclient" instead? The docs were updated but apps.json is not so this change didn't propagate in portal.

Guidance in docs:
https://raw.githubusercontent.com/MicrosoftDocs/azure-docs/master/articles/active-directory/develop/quickstart-v2-uwp.md

> #### Step 1: Configure your application
> For the code sample for this quickstart to work, you need to add a redirect URI as **https://login.microsoftonline.com/common/oauth2/nativeclient**.

One of this is incorrect, please review.