### PR TITLE
Updates direct URI and prepare for national clouds

### DIFF
--- a/AppCreationScripts/Configure.ps1
+++ b/AppCreationScripts/Configure.ps1
@@ -154,7 +154,7 @@ Function ConfigureApplications
    # Create the uwpApp AAD application
    Write-Host "Creating the AAD application (UWP-App-calling-MSGraph)"
    $uwpAppAadApplication = New-AzureADApplication -DisplayName "UWP-App-calling-MSGraph" `
-                                                  -ReplyUrls "urn:ietf:wg:oauth:2.0:oob" `
+                                                  -ReplyUrls "https://login.microsoftonline.com/common/oauth2/nativeclient" `
                                                   -AvailableToOtherTenants $True `
                                                   -PublicClient $True
 

--- a/AppCreationScripts/sample.json
+++ b/AppCreationScripts/sample.json
@@ -15,7 +15,8 @@
     {
       "Id": "uwpApp",
       "Name": "UWP-App-calling-MSGraph",
-      "Kind" :  "UWP",
+      "Kind": "UWP",
+      "RedirectUri": "https://login.microsoftonline.com/common/oauth2/nativeclient",
       "RequiredResourcesAccess": [
         {
           "Resource": "Microsoft Graph",

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ As a first step you'll need to:
    - Select **Register** to create the application.
 1. On the app **Overview** page, find the **Application (client) ID** value and record it for later. You'll need it to configure the Visual Studio configuration file for this project.
 1. In the list of pages for the app, select **Authentication**.
-   -  1. In the **Redirect URIs** list, select for **TYPE** Public client (mobile & desktop). Then paste this value **urn:ietf:wg:oauth:2.0:oob** in the **REDIRECT URI** column.
+   -  1. In the **Suggested Redirect URIs for public clients (mobile, desktop)** list, check **https://login.microsoftonline.com/common/oauth2/nativeclient**.
 1. Select **Save**.
 1. In the list of pages for the app, select **API permissions**
    - Click the **Add a permission** button and then,

--- a/active-directory-dotnet-native-uwp-v2/MainPage.xaml.cs
+++ b/active-directory-dotnet-native-uwp-v2/MainPage.xaml.cs
@@ -18,7 +18,7 @@ namespace active_directory_dotnet_native_uwp_v2
     public sealed partial class MainPage : Page
     {
         //Set the API Endpoint to Graph 'me' endpoint
-        string graphAPIEndpoint = "https://graph.microsoft.com/v1.0/me";
+        readonly string graphAPIEndpoint = "https://graph.microsoft.com/v1.0/me";
 
         //Set the scope for API call to user.read
         string[] scopes = new string[] { "user.read" };
@@ -31,7 +31,7 @@ namespace active_directory_dotnet_native_uwp_v2
         //   - for any Work or School accounts, use organizations
         //   - for any Work or School accounts, or Microsoft personal account, use common
         //   - for Microsoft Personal account, use consumers
-        private const string ClientId = "0b8b0665-bc13-4fdc-bd72-e0227b9fc011";        
+        private const string ClientId = "4a1aa1d5-c567-49d0-ad0b-cd957a47f842";        
 
         public IPublicClientApplication PublicClientApp { get; } 
 
@@ -40,13 +40,15 @@ namespace active_directory_dotnet_native_uwp_v2
             this.InitializeComponent();
 
 
+            // To change from Microsoft public cloud to a national cloud, use another value of AzureCloudInstance
             PublicClientApp = PublicClientApplicationBuilder.Create(ClientId)
-                .WithAuthority(AadAuthorityAudience.AzureAdAndPersonalMicrosoftAccount)
+                .WithAuthority(AzureCloudInstance.AzurePublic, AadAuthorityAudience.AzureAdAndPersonalMicrosoftAccount)
                 .WithLogging((level, message, containsPii) =>
                 {
                     Debug.WriteLine($"MSAL: {level} {message} ");
-                }, LogLevel.Warning, enablePiiLogging:false,enableDefaultPlatformLogging:true)
+                }, LogLevel.Warning, enablePiiLogging: false, enableDefaultPlatformLogging: true)
                 .WithUseCorporateNetwork(true)
+                .WithRedirectUri("https://login.microsoftonline.com/common/oauth2/nativeclient")
                 .Build();                
         }
 

--- a/active-directory-dotnet-native-uwp-v2/active-directory-dotnet-native-uwp-v2.csproj
+++ b/active-directory-dotnet-native-uwp-v2/active-directory-dotnet-native-uwp-v2.csproj
@@ -126,12 +126,13 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Identity.Client">
-      <Version>3.0.4-preview</Version>
+      <Version>4.8.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.2.8</Version>
+      <Version>6.2.9</Version>
     </PackageReference>
   </ItemGroup>
+  <ItemGroup />
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>
   </PropertyGroup>


### PR DESCRIPTION
- Uses the same app registration as the other public client samples
- Prepare for the National cloud quickstarts
- Updates the public client redirect URI (fixes https://github.com/Azure-Samples/active-directory-dotnet-native-uwp-v2/issues/29)
- updates MSAL to the most recent version