### PR TITLE
Fixing the quickstart automatically generarted

### DIFF
--- a/active-directory-dotnet-native-uwp-v2/Constant.cs
+++ b/active-directory-dotnet-native-uwp-v2/Constant.cs
@@ -1,0 +1,7 @@
+﻿namespace active_directory_dotnet_native_uwp_v2
+{
+    public class Constant
+    {
+        public static string PublicClientRedirectUri { get; } = "https://login.microsoftonline.com/common/oauth2/nativeclient";
+    }
+}

--- a/active-directory-dotnet-native-uwp-v2/MainPage.xaml.cs
+++ b/active-directory-dotnet-native-uwp-v2/MainPage.xaml.cs
@@ -48,7 +48,7 @@ namespace active_directory_dotnet_native_uwp_v2
                     Debug.WriteLine($"MSAL: {level} {message} ");
                 }, LogLevel.Warning, enablePiiLogging: false, enableDefaultPlatformLogging: true)
                 .WithUseCorporateNetwork(true)
-                .WithRedirectUri("https://login.microsoftonline.com/common/oauth2/nativeclient")
+                .WithRedirectUri(Constant.PublicClientRedirectUri)
                 .Build();                
         }
 

--- a/active-directory-dotnet-native-uwp-v2/active-directory-dotnet-native-uwp-v2.csproj
+++ b/active-directory-dotnet-native-uwp-v2/active-directory-dotnet-native-uwp-v2.csproj
@@ -93,6 +93,7 @@
     <Compile Include="App.xaml.cs">
       <DependentUpon>App.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Constant.cs" />
     <Compile Include="MainPage.xaml.cs">
       <DependentUpon>MainPage.xaml</DependentUpon>
     </Compile>


### PR DESCRIPTION
Making sure the string "common" is not replaced by the automated quickstart replacement in the case of the redirect URI